### PR TITLE
Consisted seqinfo data for coverage and downstream processing

### DIFF
--- a/R/PICBbuild.R
+++ b/R/PICBbuild.R
@@ -67,7 +67,7 @@ PICBbuild <- function(
         ## CLUSTER FILTERS
         THRESHOLD.SEEDS.GAP = 0, THRESHOLD.CORES.GAP = 0, THRESHOLD.CLUSTERS.GAP = 0,
         ## EXTRA OPTIONS
-        SEQ.LEVELS.STYLE = "UCSC",
+        SEQ.LEVELS.STYLE = DEFAULT.SEQ.LEVELS.STYLE,
         MIN.OVERLAP = 5,
         PROVIDE.NON.NORMALIZED = FALSE,
         COMPUTE.1U.10A.FRACTIONS = FALSE,
@@ -140,12 +140,13 @@ PICBbuild <- function(
     if (VERBOSITY > 1) message("\tSliding window analysis")
     if (VERBOSITY > 1) message("\t\tUNIQUE MAPPERS\n\t\tWINDOW: ", UNIQUEMAPPERS.SLIDING.WINDOW.WIDTH, "\n\t\tSTEP: ", UNIQUEMAPPERS.SLIDING.WINDOW.STEP)
     AG.gr <- GenomicRanges::GRanges(data.table::data.table("chr" = GenomicRanges::seqnames(SI), "start" = 1, "end" = GenomeInfoDb::seqlengths(SI), "strand" = "*"))
+    GenomicRanges::seqinfo(AG.gr) <- SI
     AG.sw.uniq <- unlist(GenomicRanges::slidingWindows(x = AG.gr, width = UNIQUEMAPPERS.SLIDING.WINDOW.WIDTH, step = UNIQUEMAPPERS.SLIDING.WINDOW.STEP))
 
     ## Make genome sliding window for multi mappers
 
     if (VERBOSITY > 1) message("\t\tPRIMARY MULTI MAPPERS\n\t\tWINDOW: ", PRIMARY.MULTIMAPPERS.SLIDING.WINDOW.WIDTH, "\n\t\tSTEP: ", PRIMARY.MULTIMAPPERS.SLIDING.WINDOW.STEP)
-    # AG.gr <- GRanges(data.table("chr"=seqnames(SI),"start"=1,"end"=seqlengths(SI),"strand"="*"))
+
     AG.sw.primary.mult <- unlist(GenomicRanges::slidingWindows(x = AG.gr, width = PRIMARY.MULTIMAPPERS.SLIDING.WINDOW.WIDTH, step = PRIMARY.MULTIMAPPERS.SLIDING.WINDOW.STEP))
     if (VERBOSITY > 1 && "multi.secondary" %in% typeAlignments) message("\t\tSECONDARY MULTI MAPPERS\n\t\tWINDOW: ", SECONDARY.MULTIMAPPERS.SLIDING.WINDOW.WIDTH, "\n\t\tSTEP: ", SECONDARY.MULTIMAPPERS.SLIDING.WINDOW.STEP)
 

--- a/R/PICBgetchromosomes.R
+++ b/R/PICBgetchromosomes.R
@@ -11,9 +11,9 @@
 #' @examples
 #' library(BSgenome.Dmelanogaster.UCSC.dm6)
 #' mySI <- PICBgetchromosomes("BSgenome.Dmelanogaster.UCSC.dm6", "UCSC")
-PICBgetchromosomes <- function(REFERENCE.GENOME, SEQ.LEVELS.STYLE = "UCSC") {
+PICBgetchromosomes <- function(REFERENCE.GENOME, SEQ.LEVELS.STYLE = DEFAULT.SEQ.LEVELS.STYLE) {
     if (typeof(REFERENCE.GENOME) == "character") {
-        SI <- GenomeInfoDb::keepStandardChromosomes(GenomeInfoDb::seqinfo(x = eval(parse(text = REFERENCE.GENOME))))
+        SI <- GenomeInfoDb::keepStandardChromosomes(GenomeInfoDb::seqinfo(x = BSgenome::getBSgenome(REFERENCE.GENOME)))
     } else {
         SI <- GenomeInfoDb::keepStandardChromosomes(REFERENCE.GENOME)
     }

--- a/R/PICBimportfromexcel.R
+++ b/R/PICBimportfromexcel.R
@@ -8,12 +8,22 @@
 #' "cores" for cores,
 #' "clusters" for clusters
 #' @export
-PICBimportfromexcel <- function(EXCEL.FILE.NAME = NULL) {
+PICBimportfromexcel <- function(EXCEL.FILE.NAME = NULL, REFERENCE.GENOME = NULL,
+        SEQ.LEVELS.STYLE = DEFAULT.SEQ.LEVELS.STYLE) {
     availbsheets <- openxlsx::getSheetNames(EXCEL.FILE.NAME)
     output <- list()
     sheetsToCheck <- intersect(availbsheets, c(uniqueonly, uniqueandprimary, allalignments))
     for (t in sheetsToCheck) {
         output[[t]] <- GenomicRanges::GRanges(openxlsx::read.xlsx(EXCEL.FILE.NAME, sheet = t))
+        
+    }
+    if (is.null(REFERENCE.GENOME)){
+        warning("REFERENCE.GENOME not providen. Cannot add chromosome length information.")
+        return(output)
+    } 
+    SI <- PICBgetchromosomes(REFERENCE.GENOME, SEQ.LEVELS.STYLE)
+    for (t in names(output)) {
+        GenomicRanges::seqinfo(output[[t]]) <- SI
     }
     return(output)
 }

--- a/R/PICBoptimize.R
+++ b/R/PICBoptimize.R
@@ -31,7 +31,7 @@ PICBoptimize <- function(
     LIBRARY.SIZE = length(IN.ALIGNMENTS$unique) + length(IN.ALIGNMENTS$multi.primary),
     VERBOSITY = 2,
     PROVIDE.INFO.SEEDS.AND.CORES = FALSE,
-    SEQ.LEVELS.STYLE = "UCSC",
+    SEQ.LEVELS.STYLE = DEFAULT.SEQ.LEVELS.STYLE,
     ...) {
 
     numberOfallReadsExplained <- function(gr, alignments) {

--- a/R/definitions.R
+++ b/R/definitions.R
@@ -1,3 +1,4 @@
 uniqueonly <- "seeds"
 uniqueandprimary <- "cores"
 allalignments <- "clusters"
+DEFAULT.SEQ.LEVELS.STYLE = "UCSC"


### PR DESCRIPTION
PICBannotate: changed the coverage length estimation to more proper way by using seqinfo property of the GRanges.

To support the consistency of seqinfo data changes were made in the following functions:
PICBload -- adding seqinfo to the alignments list
PICBbuild -- adding seqinfo to the seeds/cores/clusters list
PICBimportfromexcel.R  -- adding seqinfo to the imported seeds/cores/clusters list

Cleared the "magic number" of default SEQ.LEVELS.STYLE previously defined in multiple places. Single definition moved to definitions.R

PICBgetchromosomes: more stable BSgenome call 